### PR TITLE
feat: enhance wiki navigation with smooth scrolling and dynamic anchor links

### DIFF
--- a/www/src/components/wiki/wiki-content.tsx
+++ b/www/src/components/wiki/wiki-content.tsx
@@ -1,4 +1,43 @@
 import { cn } from '@/lib/utils';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Link05Icon } from '@hugeicons/core-free-icons';
+
+// Helper to generate ID from text content
+function generateId(children: React.ReactNode): string {
+  const text = typeof children === 'string'
+    ? children
+    : Array.isArray(children)
+      ? children.map(c => typeof c === 'string' ? c : '').join('')
+      : '';
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .trim();
+}
+
+// Anchor link component for headings
+function AnchorLink({ id }: { id: string }) {
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const url = `${window.location.pathname}${window.location.search}#${id}`;
+    window.history.pushState(null, '', url);
+    navigator.clipboard.writeText(window.location.origin + url);
+    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  return (
+    <a
+      href={`#${id}`}
+      onClick={handleClick}
+      className="ml-2 opacity-0 group-hover:opacity-100 transition-opacity text-zinc-400 hover:text-orange-500"
+      aria-label="Copy link to section"
+    >
+      <HugeiconsIcon icon={Link05Icon} size={14} strokeWidth={2} />
+    </a>
+  );
+}
 
 // Minimal reusable components
 function Section({ id, children }: { id: string; children: React.ReactNode }) {
@@ -9,16 +48,34 @@ function Section({ id, children }: { id: string; children: React.ReactNode }) {
   );
 }
 
-function H1({ children }: { children: React.ReactNode }) {
-  return <h1 className="mb-6 text-2xl font-semibold tracking-tight text-zinc-900">{children}</h1>;
+function H1({ children, id }: { children: React.ReactNode; id?: string }) {
+  const headingId = id || generateId(children);
+  return (
+    <h1 id={headingId} className="group mb-6 text-2xl font-semibold tracking-tight text-zinc-900 scroll-mt-16 flex items-center">
+      {children}
+      <AnchorLink id={headingId} />
+    </h1>
+  );
 }
 
-function H2({ children }: { children: React.ReactNode }) {
-  return <h2 className="mb-4 mt-10 text-lg font-medium text-zinc-800 first:mt-0">{children}</h2>;
+function H2({ children, id }: { children: React.ReactNode; id?: string }) {
+  const headingId = id || generateId(children);
+  return (
+    <h2 id={headingId} className="group mb-4 mt-10 text-lg font-medium text-zinc-800 first:mt-0 scroll-mt-20 flex items-center">
+      {children}
+      <AnchorLink id={headingId} />
+    </h2>
+  );
 }
 
-function H3({ children }: { children: React.ReactNode }) {
-  return <h3 className="mb-2 mt-6 text-sm font-medium text-zinc-700">{children}</h3>;
+function H3({ children, id }: { children: React.ReactNode; id?: string }) {
+  const headingId = id || generateId(children);
+  return (
+    <h3 id={headingId} className="group mb-2 mt-6 text-sm font-medium text-zinc-700 scroll-mt-20 flex items-center">
+      {children}
+      <AnchorLink id={headingId} />
+    </h3>
+  );
 }
 
 function P({ children }: { children: React.ReactNode }) {

--- a/www/src/pages/wiki.tsx
+++ b/www/src/pages/wiki.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useEffect, useCallback } from 'react';
+import { Link, useParams, useLocation, useNavigate } from 'react-router-dom';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { ArrowLeft01Icon } from '@hugeicons/core-free-icons';
 import { WikiSidebar } from '@/components/wiki/wiki-sidebar';
@@ -7,14 +7,34 @@ import { WikiContent } from '@/components/wiki/wiki-content';
 
 export function WikiPage() {
   const { section } = useParams();
-  const [activeSection, setActiveSection] = useState(section || 'getting-started');
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // URL is the single source of truth
+  const activeSection = section || 'getting-started';
+
+  // Handle section change from sidebar
+  const handleSectionChange = useCallback((newSection: string) => {
+    navigate(`/docs/${newSection}`, { replace: true });
+  }, [navigate]);
+
+  // Handle hash navigation on page load and when hash changes
+  useEffect(() => {
+    const hash = location.hash.slice(1);
+    if (hash) {
+      const timer = setTimeout(() => {
+        document.getElementById(hash)?.scrollIntoView({ behavior: 'smooth' });
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [location.hash, activeSection]);
 
   return (
     <div className="fixed inset-0 z-50 flex bg-[#fffaf5] text-zinc-900">
       {/* Sidebar */}
       <WikiSidebar
         activeSection={activeSection}
-        onSectionChange={setActiveSection}
+        onSectionChange={handleSectionChange}
       />
 
       {/* Main content */}


### PR DESCRIPTION
## Summary

- Add anchor links to wiki section headings (H1, H2, H3) for shareable URLs
- Update sidebar navigation to sync with URL
- Enable hash-based navigation to scroll directly to specific sections

## Changes

### Wiki Content (`wiki-content.tsx`)
- Added `generateId()` helper to create URL-friendly IDs from heading text
- Added `AnchorLink` component that shows a link icon on hover
- Updated `H1`, `H2`, and `H3` components to:
  - Auto-generate anchor IDs from heading text
  - Display clickable link icon on hover
  - Copy shareable URL to clipboard when clicked
  - Update browser URL with hash

### Wiki Page (`wiki.tsx`)
- Added hash navigation support via `useEffect` that scrolls to target element on page load
- Updated sidebar handler to use `navigate()` for URL updates
- Simplified state management by using URL as single source of truth (removed duplicate `useState`)

## How It Works

1. **Hover** over any heading → link icon appears
2. **Click** the icon → URL copied to clipboard, browser URL updates
3. **Share** links like `localflare.dev/docs/installation#global-installation`
4. **Open** shared link → page loads correct section and scrolls to heading