### PR TITLE
feat: auto-discover multi-worker configs and merge bindings

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { parseWranglerConfig, discoverBindings, getBindingSummary, findWranglerConfig, WRANGLER_CONFIG_FILES } from './config.js'
+export { parseWranglerConfig, discoverBindings, getBindingSummary, findWranglerConfig, WRANGLER_CONFIG_FILES, extractReferencedScriptNames, findWranglerConfigByName, resolveAllConfigs } from './config.js'
 export type {
   WranglerConfig,
   DiscoveredBindings,
@@ -9,5 +9,7 @@ export type {
   DurableObjectBinding,
   QueueProducerConfig,
   QueueConsumerConfig,
+  WorkflowConfig,
+  ServiceConfig,
   LocalflareManifest,
 } from './types.js'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,6 +8,8 @@ export interface WranglerConfig {
   r2_buckets?: R2BucketConfig[]
   durable_objects?: DurableObjectsConfig
   queues?: QueuesConfig
+  workflows?: WorkflowConfig[]
+  services?: ServiceConfig[]
   vars?: Record<string, string>
 }
 
@@ -64,6 +66,19 @@ export interface QueueConsumerConfig {
   retry_delay?: number
 }
 
+export interface WorkflowConfig {
+  name: string
+  binding: string
+  class_name: string
+  script_name?: string
+}
+
+export interface ServiceConfig {
+  binding: string
+  service: string
+  environment?: string
+}
+
 export interface DiscoveredBindings {
   d1: D1DatabaseConfig[]
   kv: KVNamespaceConfig[]
@@ -104,4 +119,5 @@ export interface LocalflareManifest {
   }
   do: { binding: string; className: string }[]
   vars: { key: string; value: string; isSecret: boolean }[]
+  workers: { name: string; configPath: string }[]
 }


### PR DESCRIPTION
This lets localflare support projects with multiple wrangler configs. It uses the `script_name` field in DO bindings, workflows, and services to discover secondary worker configs, then merges all their bindings into the shadow config with proper deduplication.