### PR TITLE
feat: bindings add per-env support retain top-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ localflare [configPath] [options]
 Options:
   -p, --port <port>        Worker port (default: 8787)
   -v, --verbose            Verbose output
+  --env <env>              Wrangler environment to use (e.g., staging, production)
   --no-open                Don't open browser automatically
   --no-tui                 Disable TUI, use simple console output
   --dev                    Open local dashboard instead of studio.localflare.dev
@@ -110,6 +111,7 @@ localflare attach [configPath] [options]
 
 Options:
   -p, --port <port>        Localflare API port (default: 8788)
+  --env <env>              Wrangler environment to use (e.g., staging, production)
   --no-open                Don't open browser automatically
   --dev                    Open local dashboard instead of studio.localflare.dev
   --persist-to <path>     Persistence directory for D1/KV/R2 data (default: .wrangler/state)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ cli
   .option('--dev', 'Open local dashboard (localhost:5174) instead of studio.localflare.dev')
   .option('--no-open', 'Do not open browser automatically')
   .option('--no-tui', 'Disable TUI, use simple console output')
+  .option('--env <env>', 'Wrangler environment to use (e.g., staging, production)')
   .option(
     '--persist-to <path>',
     'Persistence directory for D1/KV/R2 data (default: .wrangler/state)',
@@ -61,7 +62,7 @@ cli
 
     try {
       // Setup .localflare directory with shadow config
-      const { shadowConfigPath, manifest } = setupLocalflareDir(resolvedConfig, true)
+      const { shadowConfigPath, manifest } = setupLocalflareDir(resolvedConfig, true, options)
 
       // Display linked bindings
       const bindingLines = formatBindings(manifest)
@@ -231,6 +232,7 @@ cli
   .option('-p, --port <port>', 'Port for Localflare API', { default: 8788 })
   .option('--dev', 'Open local dashboard (localhost:5174) instead of studio.localflare.dev')
   .option('--no-open', 'Do not open browser automatically')
+  .option('--env <env>', 'Wrangler environment to use (e.g., staging, production)')
   .option(
     '--persist-to <path>',
     'Persistence directory for D1/KV/R2 data (default: .wrangler/state)',
@@ -265,7 +267,7 @@ cli
 
     try {
       // Setup .localflare directory (but don't add service binding - standalone mode)
-      const { shadowConfigPath, manifest } = setupLocalflareDir(resolvedConfig, false) // isPrimary=false
+      const { shadowConfigPath, manifest } = setupLocalflareDir(resolvedConfig, false, options) // isPrimary=false
 
       // Display bindings
       const bindingLines = formatBindings(manifest)

--- a/packages/cli/src/shadow-config.ts
+++ b/packages/cli/src/shadow-config.ts
@@ -9,7 +9,11 @@
 import { existsSync, mkdirSync, writeFileSync, readFileSync, cpSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { createRequire } from 'node:module'
-import { parseWranglerConfig, type WranglerConfig, type LocalflareManifest } from 'localflare-core'
+import { parseWranglerConfig, resolveWranglerConfig, type WranglerConfig, type LocalflareManifest } from 'localflare-core'
+
+export interface SetupOptions {
+  env?: string
+}
 
 /**
  * Convert Windows paths to POSIX-style (forward slashes)
@@ -190,7 +194,7 @@ script_name = "${userWorkerName}"
  * Setup the .localflare directory with shadow config and worker
  * @param isPrimary - If true, localflare-api runs as primary worker and proxies to user's worker
  */
-export function setupLocalflareDir(userConfigPath: string, isPrimary: boolean = true): {
+export function setupLocalflareDir(userConfigPath: string, isPrimary: boolean = true, options: SetupOptions = {}): {
   shadowConfigPath: string
   manifest: LocalflareManifest
 } {
@@ -202,8 +206,9 @@ export function setupLocalflareDir(userConfigPath: string, isPrimary: boolean = 
     mkdirSync(localflareDir, { recursive: true })
   }
 
-  // Parse user's config
-  const userConfig = parseWranglerConfig(userConfigPath)
+  // Parse user's config and resolve environment
+  const rawConfig = parseWranglerConfig(userConfigPath)
+  const userConfig = resolveWranglerConfig(rawConfig, options.env)
 
   // Get the pre-built worker path
   const apiWorkerPath = getApiWorkerPath()

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -64,6 +64,31 @@ export function parseWranglerConfig(configPath: string): WranglerConfig {
 }
 
 /**
+ * Resolve a wrangler config for a specific environment.
+ * Merges top-level config with env-specific overrides, matching wrangler's behavior:
+ * - Scalars (name, main, etc.) are inherited from top-level unless overridden
+ * - Binding arrays (d1_databases, kv_namespaces, etc.) are replaced entirely by env-specific values
+ * @param config - Parsed wrangler configuration
+ * @param envName - Environment name to resolve (e.g., "nonprod", "prod")
+ * @returns Resolved configuration with env bindings merged in
+ */
+export function resolveWranglerConfig(config: WranglerConfig, envName?: string): WranglerConfig {
+  if (!envName) return config
+
+  if (!config.env?.[envName]) {
+    const available = config.env ? Object.keys(config.env).join(', ') : 'none'
+    throw new Error(
+      `Environment "${envName}" not found in wrangler config. Available: ${available}`
+    )
+  }
+
+  const { env, ...topLevel } = config
+  const envOverrides = env[envName]
+
+  return { ...topLevel, ...envOverrides }
+}
+
+/**
  * Discover and extract all bindings from a wrangler configuration
  * @param config - Parsed wrangler configuration
  * @returns Discovered bindings organized by type

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { parseWranglerConfig, discoverBindings, getBindingSummary, findWranglerConfig, WRANGLER_CONFIG_FILES } from './config.js'
+export { parseWranglerConfig, resolveWranglerConfig, discoverBindings, getBindingSummary, findWranglerConfig, WRANGLER_CONFIG_FILES } from './config.js'
 export type {
   WranglerConfig,
   DiscoveredBindings,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,6 +9,7 @@ export interface WranglerConfig {
   durable_objects?: DurableObjectsConfig
   queues?: QueuesConfig
   vars?: Record<string, string>
+  env?: Record<string, Omit<WranglerConfig, 'env'>>
 }
 
 export interface D1DatabaseConfig {


### PR DESCRIPTION
Wrangler configs can define bindings in two ways:

**Top-level (what localflare supported before)**:
```
  {
    "name": "my-worker",
    "d1_databases": [{ "binding": "DB", ... }]
  }
```

**Per-environment (what some projects use)**:
```
  {
    "name": "my-worker",
    "env": {
      "nonprod": {
        "d1_databases": [{ "binding": "DB", ... }],
        "durable_objects": { ... },
        "kv_namespaces": [...]
      },
      "prod": {
        "d1_databases": [{ "binding": "DB", ... }]
      }
    }
  }
```

  Localflare was only reading top-level properties. If all bindings lived inside env.nonprod, the manifest came back empty — no D1, no KV, no DO, nothing to show in the dashboard.

`resolveWranglerConfig` flattens a specific env into a top-level config so the rest of localflare works as before. `--env nonprod` tells it which section to use.